### PR TITLE
Fix Ctrl + Z & Ctrl + Y not saving the allocated attribute stats

### DIFF
--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -1947,7 +1947,7 @@ function PassiveSpecClass:CreateUndoState()
 		secondaryAscendClassId = self.secondaryAscendClassId,
 		hashList = allocNodeIdList,
 		weaponSets = weaponSets,
-		hashOverrides = self.hashOverrides,
+		hashOverrides = copyTable(self.hashOverrides, true),
 		masteryEffects = selections,
 		treeVersion = self.treeVersion
 	}


### PR DESCRIPTION
Fixes [#302](https://github.com/PathOfBuildingCommunity/PathOfBuilding-PoE2/issues/302)

### Description of the problem being solved:
The createUndoState for Spec wasn't copying the hashOverrides correctly, so if you control-z after decallocated any attribute node, it reallocates as an empty Attribute and not whichever was set before. 

### Steps taken to verify a working solution:
- Deallocate attribute node
- Ctrl-Z
- Validate previous attribute stat is reallocated
- Single attribute node, long path of nodes, goldilocks length of nodes
- After undoing a deallocation, save and load a validate all nodes are still correct/hashOverrides are correct

### Before screenshot:
![attributeUndoBad](https://github.com/user-attachments/assets/02afeba2-c59b-45a1-bfec-8aaf3eb1aecd)

### After screenshot:

![attributeUndo](https://github.com/user-attachments/assets/34b1905b-c437-4456-abbf-8545d90469bb)

