### PR TITLE
Fix crash when allocating some nodes with weapon set passives

### DIFF
--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -157,7 +157,7 @@ function calcs.buildModListForNode(env, node, incSmallPassiveSkill)
 			local added = false
 			for j, extra in ipairs(mod) do
 				-- if type conditional and start with WeaponSet then update the var to the current weapon set
-				if extra.type == "Condition" and extra.var:match("^WeaponSet") then
+				if extra.type == "Condition" and extra.var and extra.var:match("^WeaponSet") then
 					mod[j].var = "WeaponSet".. node.allocMode
 					added = true
 					break


### PR DESCRIPTION
mod type condition can have varList instead of var, this pr validate
if we have var and the check if this condition if about weaponSet
closes https://github.com/PathOfBuildingCommunity/PathOfBuilding-PoE2/issues/317
