### PR TITLE
Fix damage scaling with Mace Strike, Bow Shot, Concoction, and other skills

### DIFF
--- a/src/Data/Skills/other.lua
+++ b/src/Data/Skills/other.lua
@@ -186,6 +186,9 @@ skills["BleedingConcoctionPlayer"] = {
 			damageIncrementalEffectiveness = 0.0065000001341105,
 			statDescriptionScope = "throw_flask_bleed",
 			baseFlags = {
+				attack = true,
+				area = true,
+				projectile = true,
 			},
 			constantStats = {
 				{ "additional_base_critical_strike_chance", 500 },
@@ -314,6 +317,8 @@ skills["MeleeBowPlayer"] = {
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "skill_stat_descriptions",
 			baseFlags = {
+				attack = true,
+				projectile = true,
 			},
 			constantStats = {
 				{ "movement_speed_+%_final_while_performing_action", -70 },
@@ -734,6 +739,8 @@ skills["ElementalExpressionTriggeredPlayer"] = {
 			damageIncrementalEffectiveness = 0.0065000001341105,
 			statDescriptionScope = "skill_stat_descriptions",
 			baseFlags = {
+				spell = true,
+				area = true,
 			},
 			constantStats = {
 				{ "active_skill_base_area_of_effect_radius", 36 },
@@ -795,6 +802,8 @@ skills["ElementalExpressionTriggeredPlayer"] = {
 			damageIncrementalEffectiveness = 0.0065000001341105,
 			statDescriptionScope = "skill_stat_descriptions",
 			baseFlags = {
+				spell = true,
+				projectile = true,
 			},
 			constantStats = {
 				{ "base_number_of_projectiles", 3 },
@@ -859,6 +868,8 @@ skills["ElementalExpressionTriggeredPlayer"] = {
 			damageIncrementalEffectiveness = 0.0065000001341105,
 			statDescriptionScope = "skill_stat_descriptions",
 			baseFlags = {
+				spell = true,
+				chaining = true,
 			},
 			constantStats = {
 				{ "number_of_chains", 7 },
@@ -975,6 +986,8 @@ skills["ElementalStormPlayer"] = {
 			damageIncrementalEffectiveness = 0.0065000001341105,
 			statDescriptionScope = "tornado_triggered",
 			baseFlags = {
+				area = true,
+				duration = true,
 			},
 			constantStats = {
 				{ "tornado_base_damage_interval_ms", 250 },
@@ -1041,6 +1054,9 @@ skills["ElementalStormPlayer"] = {
 			damageIncrementalEffectiveness = 0.0065000001341105,
 			statDescriptionScope = "tornado_triggered",
 			baseFlags = {
+				spell = true,
+				area = true,
+				duration = true,
 			},
 			constantStats = {
 				{ "tornado_base_damage_interval_ms", 250 },
@@ -1109,6 +1125,9 @@ skills["ElementalStormPlayer"] = {
 			damageIncrementalEffectiveness = 0.0065000001341105,
 			statDescriptionScope = "tornado_triggered",
 			baseFlags = {
+				spell = true,
+				area = true,
+				duration = true,
 			},
 			constantStats = {
 				{ "tornado_base_damage_interval_ms", 250 },
@@ -1177,6 +1196,9 @@ skills["ElementalStormPlayer"] = {
 			damageIncrementalEffectiveness = 0.0065000001341105,
 			statDescriptionScope = "tornado_triggered",
 			baseFlags = {
+				spell = true,
+				area = true,
+				duration = true,
 			},
 			constantStats = {
 				{ "tornado_base_damage_interval_ms", 250 },
@@ -1299,6 +1321,7 @@ skills["EncaseInJadePlayer"] = {
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "encase_in_jade",
 			baseFlags = {
+				duration = true,
 			},
 			constantStats = {
 				{ "base_skill_effect_duration", 4000 },
@@ -1413,6 +1436,10 @@ skills["ExplosiveConcoctionPlayer"] = {
 			damageIncrementalEffectiveness = 0.0065000001341105,
 			statDescriptionScope = "throw_flask_fire",
 			baseFlags = {
+				attack = true,
+				area = true,
+				projectile = true,
+				duration = true,
 			},
 			constantStats = {
 				{ "additional_base_critical_strike_chance", 500 },
@@ -1541,6 +1568,10 @@ skills["FulminatingConcoctionPlayer"] = {
 			damageIncrementalEffectiveness = 0.0065000001341105,
 			statDescriptionScope = "throw_flask_lightning",
 			baseFlags = {
+				attack = true,
+				area = true,
+				projectile = true,
+				duration = true,
 			},
 			constantStats = {
 				{ "additional_base_critical_strike_chance", 800 },
@@ -1898,6 +1929,9 @@ skills["Melee1HMacePlayer"] = {
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "skill_stat_descriptions",
 			baseFlags = {
+				attack = true,
+				area = true,
+				melee = true,
 			},
 			constantStats = {
 				{ "melee_conditional_step_distance", 10 },
@@ -2011,6 +2045,9 @@ skills["Melee2HMacePlayer"] = {
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "skill_stat_descriptions",
 			baseFlags = {
+				attack = true,
+				area = true,
+				melee = true,
 			},
 			constantStats = {
 				{ "melee_conditional_step_distance", 10 },
@@ -2125,6 +2162,9 @@ skills["MeleeMaceMacePlayer"] = {
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "skill_stat_descriptions",
 			baseFlags = {
+				attack = true,
+				area = true,
+				melee = true,
 			},
 			constantStats = {
 				{ "melee_conditional_step_distance", 10 },
@@ -2355,6 +2395,9 @@ skills["PoisonousConcoctionPlayer"] = {
 			damageIncrementalEffectiveness = 0.0065000001341105,
 			statDescriptionScope = "throw_flask_poison",
 			baseFlags = {
+				attack = true,
+				area = true,
+				projectile = true,
 			},
 			constantStats = {
 				{ "additional_base_critical_strike_chance", 500 },
@@ -2752,6 +2795,10 @@ skills["ShatteringConcoctionPlayer"] = {
 			damageIncrementalEffectiveness = 0.0065000001341105,
 			statDescriptionScope = "throw_flask_cold",
 			baseFlags = {
+				attack = true,
+				area = true,
+				projectile = true,
+				duration = true,
 			},
 			constantStats = {
 				{ "additional_base_critical_strike_chance", 1100 },
@@ -3226,6 +3273,8 @@ skills["TimeFreezePlayer"] = {
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "time_stop",
 			baseFlags = {
+				area = true,
+				duration = true,
 			},
 			constantStats = {
 				{ "base_skill_effect_duration", 3000 },

--- a/src/Export/Skills/other.txt
+++ b/src/Export/Skills/other.txt
@@ -18,7 +18,7 @@ local skills, mod, flag, skill = ...
 #skill BleedingConcoctionPlayer
 #startSets
 #set BleedingConcoctionPlayer
-#flags
+#flags attack area projectile
 #mods
 #skillEnd
 
@@ -26,7 +26,7 @@ local skills, mod, flag, skill = ...
 #skill MeleeBowPlayer
 #startSets
 #set MeleeBowPlayer
-#flags
+#flags attack projectile
 #mods
 #skillEnd
 
@@ -53,13 +53,13 @@ local skills, mod, flag, skill = ...
 #flags
 #mods
 #set ElementalExpressionFirePlayer
-#flags
+#flags spell area
 #mods
 #set ElementalExpressionColdPlayer
-#flags
+#flags spell projectile
 #mods
 #set ElementalExpressionLightningPlayer
-#flags
+#flags spell chaining
 #mods
 #skillEnd
 
@@ -67,16 +67,16 @@ local skills, mod, flag, skill = ...
 #skill ElementalStormPlayer
 #startSets
 #set ElementalStormPlayer
-#flags
+#flags area duration
 #mods
 #set ElementalStormFirePlayer
-#flags
+#flags spell area duration
 #mods
 #set ElementalStormLightningPlayer
-#flags
+#flags spell area duration
 #mods
 #set ElementalStormColdPlayer
-#flags
+#flags spell area duration
 #mods
 #skillEnd
 
@@ -84,7 +84,7 @@ local skills, mod, flag, skill = ...
 #skill EncaseInJadePlayer
 #startSets
 #set EncaseInJadePlayer
-#flags
+#flags duration
 #mods
 #skillEnd
 
@@ -92,7 +92,7 @@ local skills, mod, flag, skill = ...
 #skill ExplosiveConcoctionPlayer
 #startSets
 #set ExplosiveConcoctionPlayer
-#flags
+#flags attack area projectile duration
 #mods
 #skillEnd
 
@@ -100,7 +100,7 @@ local skills, mod, flag, skill = ...
 #skill FulminatingConcoctionPlayer
 #startSets
 #set FulminatingConcoctionPlayer
-#flags
+#flags attack area projectile duration
 #mods
 #skillEnd
 
@@ -124,7 +124,7 @@ local skills, mod, flag, skill = ...
 #skill Melee1HMacePlayer
 #startSets
 #set Melee1HMacePlayer
-#flags
+#flags attack area melee
 #mods
 #skillEnd
 
@@ -132,7 +132,7 @@ local skills, mod, flag, skill = ...
 #skill Melee2HMacePlayer
 #startSets
 #set Melee2HMacePlayer
-#flags
+#flags attack area melee
 #mods
 #skillEnd
 
@@ -140,7 +140,7 @@ local skills, mod, flag, skill = ...
 #skill MeleeMaceMacePlayer
 #startSets
 #set MeleeMaceMacePlayer
-#flags
+#flags attack area melee
 #mods
 #skillEnd
 
@@ -156,7 +156,7 @@ local skills, mod, flag, skill = ...
 #skill PoisonousConcoctionPlayer
 #startSets
 #set PoisonousConcoctionPlayer
-#flags
+#flags attack area projectile
 #mods
 #skillEnd
 
@@ -188,7 +188,7 @@ local skills, mod, flag, skill = ...
 #skill ShatteringConcoctionPlayer
 #startSets
 #set ShatteringConcoctionPlayer
-#flags
+#flags attack area projectile duration
 #mods
 #skillEnd
 
@@ -221,7 +221,7 @@ local skills, mod, flag, skill = ...
 #skill TimeFreezePlayer
 #startSets
 #set TimeFreezePlayer
-#flags
+#flags area duration
 #mods
 #skillEnd
 


### PR DESCRIPTION
Fixes [#303](https://github.com/PathOfBuildingCommunity/PathOfBuilding-PoE2/issues/303)

### Description of the problem being solved:
Add tags to other.txt and export. Bow Shot, Mace Strike, Concoctions, ElementalStorm and so on

### Steps taken to verify a working solution:
![image](https://github.com/user-attachments/assets/eab6977f-90f4-4cb1-8f3d-6ba766ba58dc)

### Link to a build that showcases this PR:
<pre>eNqlW1tz2zoOfq5_Bccz-7aNL02ayzg949hOk5k48dppu_vUYSTa5oYSXYlK4vPrD0DqZseUKSedaSQRHwCCBAhASu-vt0CQFxbFXIaXzc5Ru0lY6Emfh4vL5o_H689nzb--NXoTqpYP86uECxzpfmt86ukbItgLEwBsEk_QOL6nAbtsTmm4YFGT0NhjoT8oBu5lyJpE0WjB1M9MaPs3opc0op5i0R0y7CdKjqUPCBUlgAgoD2fSe2bqeySTlZb3wtmrobkdTx6mj01Q6lNvIuiaRTNFFYnhv8tmHyZHF2xIA_gfUFQkAOmcnxwdtzunJ-3O2df2abNVCb5KolgdxmG2YswvQEcdG-EkYqP5nHmKv7BBxNVgSUOvEHdiw-2gbR99raIeJ0LxleC4Qimia6O_ece8Y6V9lIqK4WRWcO0cH50fd867J9328dezapxUhf42yl9cLa8EGPQAKYi9XYRcsQPBE8ljGX5gfmWodYqDRAjwMCfaKYtZ9EIV31TLzlsGTzw8yHpjGtKBjB3WCCknLALHV7UAM-ZJiBV1ZdRE3vE5c6esNY8UUFebw-YxmrnS1WZ8mEJTiI1ulDOZCEdKVUSoU7sT_CnTde3xacjeiihmjae3odovdMheJLrd_jlo5x_dTIpADmfs8Ukbjo5u-_zUGqgny3XMPSrG9I0HSQBx-JE-s0Lg11P7plosVQgxxAY9tkKvecTqowZS-AegllTG9Wc3hkzghoZ-3_MSSBjWxVqdVHmZA2c4qb0LpL0NvZz8rIrpjzDSEbh0wFcty5xNwaEwo3gSzBFRiEjdstjB7Xa1qAULU3lrt0h0x5i3_A72nVLF3IJwsc5nlWZF2rJZK5nuMOvxmRughpEQuNtInaPzKlBNM81WHHIuF40M5Y7Z18DUMMAoZNFiPVtyJnyHc6FEnVlsQFcu84f1L6Od9sGmuFpbuQytuVa_aOS7HXV1dXqhcfm4-LLHXIbczWMYJMQA8Nl2FWCvNOT_sc4Q9WD9KJBJ5LjghthpAtlJZ-qrKfMTz-1ozculKwGloes0chToKUQtaF8p6j0Ppb9wNpoWUguxqd8sWa3At3E3uDLAQxwqA17KsD4fO1A_wFZ28mg8790FFNTOAvIMxl3KFsR9LpiFbIlxIXYWkC_nGEJFAKFZNwTGshTdrUsDpaBTXacJHevLiXwFzZfYgYnrUUOuVsQvqyoRC_9eO_PfIHcSMAp9yPvAEZxlbCN2iblK5vOYeFAfU3UHy3vZbJIneJZdQ64Zs_TGIB55AIE3jodUUeKn5cBPGnEaqq7uT8WMRt4SQddUiCeIHMipeIp3W8BOtht6Ld1dw6vbYCUjRdgb_prQSK0vm3MqYmYI9RPgEyse6k4AhCkhmmS2lK99_wXn_SiliDMQoasVC_0NHo8RY4RmQcdDJfQc8YYENFZwxpl9HKPSpa7erY-GJ6EEBaC0gcLmHKeIZSON1v1NwpCDXgpkbXX-CkYo9VPvx_ROX3xaKrWKL1qt19fXoxVVSzlnb3BqHcE6tVYAAn0_x89ciM_ItdWHn6tFX_9oRq2MU8_0DuOWuUPnjTiobMT0IK5H_ClRLBsAe77dmzk1CQ9Vfh2rKLtOebU2mPVaaDO9gGhUvLiXyozhw-ymN0O1YxLDmn5nQXy1Bue9xoxlq0uTrgpSz5gy-6qMyRqkPpvTRODz_yRUcNwk7fLTO9OmDWUU5DUlsIJNgieM4fi4XuHM-nd36fKnUgn3sy2RPtT92H6h2oAKL9bK8dATiQ8lVBq80lUX9AnFY28Zix-_3Nct8cnFfOqBPinxdyGfqOhmkLTh3G03N8Y72fiLcSXcUCYUDI0Rujdjisen3jA4qhMn89QQNsmfku0WLDBUivrg461bBTZvgVotrSpc7GQf0iB1IrwnM9hZz-zdvD2ZhCoP_bhtkGe6g1Kz611k9gleahtrittwlSgt6LIZ8Nj7jZEKO-F6f-rG_ej6ejR4vP05SqNVGaIN8DtMgiecsvldnEIzprMvEidPsbm8bP7k7FUrMgRjcBGj_kLQVczyOKL3SKq5AFwFN00FFX_WT9_NqyCwcxq9sQjC3gLSdi_izKpXPr5HKSMQU3qM7jZu2Km2MzI54gCCpik5LJbSbwXsXLBNb50ODlZg4cCgwio5Hd1jCYWhAHYxn3MPj9LqJcfAYagq7JL3a6zrnSa4dh669W9jYAbtYNO-t6HT0Qqr6lcHVquaUTt8yDxqnbsZtIPzKlaGN9hK2M0lp6rgdC9DvcnBafpcYDpqXdmRYDmJneGDWrIozQ1snMYQozKSSscxh7CVT4miwla62WexEI7ZoaahZZkDjlU4TdrksXk7r3bZzVaMZT3KNHZWpoVhjYNVUFPZWM2fVkkVK5g2CCyrZ0YrjJD1SCzzT4crfEyH7_6L5L6plC3etkVWFW8gbfw4G13-f5zNdj_g4xyvIfN-tq53OmqH_1Acs6UdXEyS48QEffJjHNA1P8YBC8PgYPR0O4spsNPq_CUvYXeCs9GqsJFWtgdzMPX3wXDdHjgYrc8OSJ8ZzKDy8MhpKpxDJeEQjKEqHMORlVZrdxQpZleLlzlGd860Nkfj3enbsqoAYEj2MII84KYi03TjlLe4bhgV-J2EFB9j-O6t4EeYYZM-WdHQz9g97Mrvi3VwtJ5UMfDUXZohvgv4qA1DFqx3MLLr1WtlFaHu32CNljaXoObEUvtvKYP_6VIWr9IGwJe06Idsfchh3SK93zI5SPjfrJXW0xVv2oHA67wBYWeQxMx8NPCL0ZUMNQIbAKYIBR7lXsIUKnW1viDT_nTUuAf1kaAxeltBVUcGERSm-CUMGUN53RhEdK6Yf0FQTmMSsTl_uyD4OVnFzQzqYoebtGNyQbrtRtoouiAz_NeYJiFLqXZfarNO2Z8LcnregNpKcI8jvNMYUDBGTHBhofQkShKYmYAqncDSYwmH7zwIlk__JnMZkU77X0TOCQQMHhE8FQmNSfZuhJjV1_0BtFJuT2zP2Iy-2bcRUhGoUYLJ04_pHe4P0w34LqDehT2HQ6YJ16oGGCGkU0A6-yD6CC0j9grpB4lgqgZAH-HkS21EHaXMNLr1bVUHcsWEOmA1yOwV30Y446boWbX0kv6aZBl-bQMcpF6n9mrWmdANg1NZ1bKAVO8dxfhj1q7TIVN362Q454s0eJqbNHxqUP5kw0fLXToviZUMxtKPi65epw0xgodexCgcDgRfQDDim8iwNUbht21Id6gsg6ss4Pil5pt-qeKxpRQ-i1L9GB5Y6cetWQ_xtN3eA9h43ZbB9oHyd3tZxzDvWba73X0CS1_HZrCTPZjyC9Qcs3dm8OQA_VDWATB97BSIs2M7fZB_7YsfscJ57c90hxI70DMm5iW5Jw5zrG2YfPUmmMllsC-uqPoLgVts26TH7fM9sLz7kNu0yqizJeQJ2o7xuxa6VcTmhw71tjE8cbXfzJM6CaynHDrKtmJf9tk6Ow9yId2z832Y9DMPSHH1XwmUo4cdGfMFFw9zXW_CzHTR7DozdDFX2w2W-AZjt-kg4c6itkm_9d23Rq_17o8j_gERlwMz</pre>

### Before screenshot:
![image](https://github.com/user-attachments/assets/74368cc4-b6f6-47f3-b97d-38228e8c762f)

### After screenshot:
![image](https://github.com/user-attachments/assets/09434b2f-bad4-431d-87c7-e228c83a72d6)
