### PR TITLE
Add support for importing builds from PoE2DB

### DIFF
--- a/src/Modules/BuildSiteTools.lua
+++ b/src/Modules/BuildSiteTools.lua
@@ -20,6 +20,10 @@ buildSites.websiteList = {
 		label = "PoeNinja", id = "PoeNinja", matchURL = "poe%.ninja/pob/%w+", regexURL = "poe%.ninja/pob/(%w+)%s*$", downloadURL = "poe.ninja/pob/raw/%1",
 		codeOut = "", postUrl = "https://poe.ninja/pob/api/api_post.php", postFields = "api_paste_code=", linkURL="poe.ninja/pob/%1"
 	},
+	{ 
+		label = "poe2db.tw", id = "PoE2DB", matchURL = "poe2db%.tw/.+", regexURL = "poe2db%.tw/pob/(.+)%s*$", downloadURL = "poe2db.tw/pob/%1/raw", 
+		codeOut = "", postUrl = "https://poe2db.tw/pob/api/gen", postFields = "", linkURL = "poe2db.tw/pob/%1" 
+	},
 	{
 		label = "Pastebin.com", id = "pastebin", matchURL = "pastebin%.com/%w+", regexURL = "pastebin%.com/(%w+)%s*$", downloadURL = "pastebin.com/raw/%1", linkURL = "pastebin.com/%1"
 	},


### PR DESCRIPTION
Fixes [#305](https://github.com/PathOfBuildingCommunity/PathOfBuilding-PoE2/issues/305)

### Description of the problem being solved:
Adds poe2db to import list

### Link to a build that showcases this PR:
<pre>https://poe2db.tw/pob/tLMZfMOsWL</pre>

![image](https://github.com/user-attachments/assets/7a516aac-5a41-4161-a7b2-fa631f1032dd)

![image](https://github.com/user-attachments/assets/1d6915ac-f3bc-4a9e-a8c9-4aea1b1b952e)
