### PR TITLE
Fix some increased critical damage modifiers incorrectly applying as base critical damage modifiers

### DIFF
--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -599,7 +599,7 @@ return {
 	flag("NeverCrit"),
 },
 ["base_critical_strike_multiplier_+"] = {
-	mod("CritMultiplier", "BASE", nil),
+	mod("CritMultiplier", "INC", nil),
 },
 ["critical_strike_chance_+%_vs_shocked_enemies"] = {
 	mod("CritChance", "INC", nil, 0, 0, { type = "ActorCondition", actor = "enemy", var = "Shocked" }),


### PR DESCRIPTION
Fixes https://github.com/PathOfBuildingCommunity/PathOfBuilding-PoE2/issues/211
Fixes https://github.com/PathOfBuildingCommunity/PathOfBuilding-PoE2/issues/267

This affects Supercritical, Snipe and Sunder

### Before screenshot:
![image](https://github.com/user-attachments/assets/6a621642-6795-46e1-a306-ee6159c06934)
### After screenshot:
![image](https://github.com/user-attachments/assets/e25cb82d-3ccc-4515-a09e-a0a4b3644de5)
