### PR TITLE
Fix for issue #112

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -725,15 +725,24 @@ function calcs.defence(env, actor)
 	end
 	output.BlockChanceOverCap = 0
 	output.SpellBlockChanceOverCap = 0
+	
 	local baseBlockChance = 0
 	if actor.itemList["Weapon 2"] and actor.itemList["Weapon 2"].armourData then
-		baseBlockChance = baseBlockChance + (actor.itemList["Weapon 2"].armourData.BlockChance or 0)
+		if env.allocNodes[23005] and actor.itemList["Weapon 2"].type == "Shield" then
+			baseBlockChance = baseBlockChance + 40
+		else
+			baseBlockChance = baseBlockChance + (actor.itemList["Weapon 2"].armourData.BlockChance or 0)
+		end
 	end
+
 	if actor.itemList["Weapon 3"] and actor.itemList["Weapon 3"].armourData then
-		baseBlockChance = baseBlockChance + (actor.itemList["Weapon 3"].armourData.BlockChance or 0)
+		if env.allocNodes[23005] and actor.itemList["Weapon 3"].type == "Shield" then
+			baseBlockChance = baseBlockChance + 40
+		else
+			baseBlockChance = baseBlockChance + (actor.itemList["Weapon 3"].armourData.BlockChance or 0)
+		end
 	end
-	output.ShieldBlockChance = baseBlockChance
-	baseBlockChance = modDB:Override(nil, "ReplaceShieldBlock") or baseBlockChance
+
 	if modDB:Flag(nil, "BlockAttackChanceIsEqualToParent") then
 		output.BlockChance = m_min(actor.parent.output.BlockChance, output.BlockChanceMax)
 	elseif modDB:Flag(nil, "BlockAttackChanceIsEqualToPartyMember") then

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -725,24 +725,15 @@ function calcs.defence(env, actor)
 	end
 	output.BlockChanceOverCap = 0
 	output.SpellBlockChanceOverCap = 0
-	
 	local baseBlockChance = 0
 	if actor.itemList["Weapon 2"] and actor.itemList["Weapon 2"].armourData then
-		if env.allocNodes[23005] and actor.itemList["Weapon 2"].type == "Shield" then
-			baseBlockChance = baseBlockChance + 40
-		else
-			baseBlockChance = baseBlockChance + (actor.itemList["Weapon 2"].armourData.BlockChance or 0)
-		end
+		baseBlockChance = baseBlockChance + (actor.itemList["Weapon 2"].armourData.BlockChance or 0)
 	end
-
 	if actor.itemList["Weapon 3"] and actor.itemList["Weapon 3"].armourData then
-		if env.allocNodes[23005] and actor.itemList["Weapon 3"].type == "Shield" then
-			baseBlockChance = baseBlockChance + 40
-		else
-			baseBlockChance = baseBlockChance + (actor.itemList["Weapon 3"].armourData.BlockChance or 0)
-		end
+		baseBlockChance = baseBlockChance + (actor.itemList["Weapon 3"].armourData.BlockChance or 0)
 	end
-
+	output.ShieldBlockChance = baseBlockChance
+	baseBlockChance = modDB:Override(nil, "ReplaceShieldBlock") or baseBlockChance
 	if modDB:Flag(nil, "BlockAttackChanceIsEqualToParent") then
 		output.BlockChance = m_min(actor.parent.output.BlockChance, output.BlockChanceMax)
 	elseif modDB:Flag(nil, "BlockAttackChanceIsEqualToPartyMember") then

--- a/src/Modules/ItemTools.lua
+++ b/src/Modules/ItemTools.lua
@@ -320,7 +320,7 @@ end
 
 function itemLib.formatModLine(modLine, dbMode)
 	local line = (not dbMode and modLine.range and itemLib.applyRange(modLine.line, modLine.range, modLine.valueScalar, modLine.corruptedRange)) or modLine.line
-	if line:match("^%+?0%%? ") or (line:match(" %+?0%%? ") and not line:match("0 to [1-9]")) or line:match(" 0%-0 ") or line:match(" 0 to 0 ") then -- Hack to hide 0-value modifiers
+	if not line:match("^Gain %d+%% to %d+%%") and (line:match("^%+?0%%? ") or (line:match(" %+?0%%? ") and not line:match("0 to [1-9]")) or line:match(" 0%-0 ") or line:match(" 0 to 0 ")) then -- Hack to hide 0-value modifiers
 		return
 	end
 	local colorCode


### PR DESCRIPTION
Fixes [#112](https://github.com/PathOfBuildingCommunity/PathOfBuilding-PoE2/issues/112#issue-2779621550) .

### Description of the problem being solved:
Gamblesprint not showing movement speed modifier. Check for modifiers with '0' value filtered out the mod. Added logic to allow this one through.

### Steps taken to verify a working solution:
- Verified by checking item in item tab

### Before screenshot:
![image](https://github.com/user-attachments/assets/4c22eacf-53af-48cc-b2a3-8b34cde6f2f1)


### After screenshot:
![image](https://github.com/user-attachments/assets/de134730-4dc3-4923-a42b-285b20872a0e)
