### PR TITLE
Fix weapon tree hotkey overriding other tree hotkeys

### DIFF
--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -89,10 +89,10 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 					-- Dragging won't actually commence unless the cursor moves far enough
 					self.dragX, self.dragY = cursorX, cursorY
 				end
-			elseif mOver then
-				if IsKeyDown("ALT") and event.key == "WHEELDOWN" then
+			elseif IsKeyDown("ALT") and mOver then
+				if event.key == "WHEELDOWN" then
 					spec.allocMode = math.max(0, spec.allocMode - 1)
-				elseif IsKeyDown("ALT") and event.key == "WHEELUP" then
+				elseif event.key == "WHEELUP" then
 					spec.allocMode = math.min(2, spec.allocMode + 1)
 				end
 			elseif event.key == "p" then


### PR DESCRIPTION
Fixes https://github.com/PathOfBuildingCommunity/PathOfBuilding-PoE2/issues/351#issuecomment-2599924420

### Description of the problem being solved:
Checking `mOver` first meant every hotkey defined after that branch wouldn't get recognized, including PageUp/Down, Ctrl+D, and even the wiki
### Steps taken to verify a working solution:
- Tested all listed hotkeys
- Ensured weapon tree switching still worked