### PR TITLE
Show Movement Speed mod on Gamble Sprint

### DIFF
--- a/src/Data/Uniques/boots.lua
+++ b/src/Data/Uniques/boots.lua
@@ -82,9 +82,7 @@ Variant: Current
 (100-140)% increased Evasion Rating
 {variant:2}(10-15)% increased Rarity of Items found
 +(10-15) to Dexterity
-{variant:1}+(5-15)% to Lightning Resistance
-{variant:2}+(15-25)% to Lightning Resistance
-+(15-25)% to Lightning Resistance
++(5-15)% to Lightning Resistance
 Gain 0% to 40% increased Movement Speed at random when Hit, until Hit again
 ]],[[
 Thunderstep

--- a/src/Data/Uniques/boots.lua
+++ b/src/Data/Uniques/boots.lua
@@ -82,7 +82,8 @@ Variant: Current
 (100-140)% increased Evasion Rating
 {variant:2}(10-15)% increased Rarity of Items found
 +(10-15) to Dexterity
-+(5-15)% to Lightning Resistance
+{variant:1}+(5-15)% to Lightning Resistance
+{variant:2}+(15-25)% to Lightning Resistance
 Gain 0% to 40% increased Movement Speed at random when Hit, until Hit again
 ]],[[
 Thunderstep

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -725,15 +725,24 @@ function calcs.defence(env, actor)
 	end
 	output.BlockChanceOverCap = 0
 	output.SpellBlockChanceOverCap = 0
+	
 	local baseBlockChance = 0
 	if actor.itemList["Weapon 2"] and actor.itemList["Weapon 2"].armourData then
-		baseBlockChance = baseBlockChance + (actor.itemList["Weapon 2"].armourData.BlockChance or 0)
+		if env.allocNodes[23005] and actor.itemList["Weapon 2"].type == "Shield" then
+			baseBlockChance = baseBlockChance + 40
+		else
+			baseBlockChance = baseBlockChance + (actor.itemList["Weapon 2"].armourData.BlockChance or 0)
+		end
 	end
+
 	if actor.itemList["Weapon 3"] and actor.itemList["Weapon 3"].armourData then
-		baseBlockChance = baseBlockChance + (actor.itemList["Weapon 3"].armourData.BlockChance or 0)
+		if env.allocNodes[23005] and actor.itemList["Weapon 3"].type == "Shield" then
+			baseBlockChance = baseBlockChance + 40
+		else
+			baseBlockChance = baseBlockChance + (actor.itemList["Weapon 3"].armourData.BlockChance or 0)
+		end
 	end
-	output.ShieldBlockChance = baseBlockChance
-	baseBlockChance = modDB:Override(nil, "ReplaceShieldBlock") or baseBlockChance
+
 	if modDB:Flag(nil, "BlockAttackChanceIsEqualToParent") then
 		output.BlockChance = m_min(actor.parent.output.BlockChance, output.BlockChanceMax)
 	elseif modDB:Flag(nil, "BlockAttackChanceIsEqualToPartyMember") then

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -725,24 +725,15 @@ function calcs.defence(env, actor)
 	end
 	output.BlockChanceOverCap = 0
 	output.SpellBlockChanceOverCap = 0
-	
 	local baseBlockChance = 0
 	if actor.itemList["Weapon 2"] and actor.itemList["Weapon 2"].armourData then
-		if env.allocNodes[23005] and actor.itemList["Weapon 2"].type == "Shield" then
-			baseBlockChance = baseBlockChance + 40
-		else
-			baseBlockChance = baseBlockChance + (actor.itemList["Weapon 2"].armourData.BlockChance or 0)
-		end
+		baseBlockChance = baseBlockChance + (actor.itemList["Weapon 2"].armourData.BlockChance or 0)
 	end
-
 	if actor.itemList["Weapon 3"] and actor.itemList["Weapon 3"].armourData then
-		if env.allocNodes[23005] and actor.itemList["Weapon 3"].type == "Shield" then
-			baseBlockChance = baseBlockChance + 40
-		else
-			baseBlockChance = baseBlockChance + (actor.itemList["Weapon 3"].armourData.BlockChance or 0)
-		end
+		baseBlockChance = baseBlockChance + (actor.itemList["Weapon 3"].armourData.BlockChance or 0)
 	end
-
+	output.ShieldBlockChance = baseBlockChance
+	baseBlockChance = modDB:Override(nil, "ReplaceShieldBlock") or baseBlockChance
 	if modDB:Flag(nil, "BlockAttackChanceIsEqualToParent") then
 		output.BlockChance = m_min(actor.parent.output.BlockChance, output.BlockChanceMax)
 	elseif modDB:Flag(nil, "BlockAttackChanceIsEqualToPartyMember") then

--- a/src/Modules/ItemTools.lua
+++ b/src/Modules/ItemTools.lua
@@ -320,7 +320,7 @@ end
 
 function itemLib.formatModLine(modLine, dbMode)
 	local line = (not dbMode and modLine.range and itemLib.applyRange(modLine.line, modLine.range, modLine.valueScalar, modLine.corruptedRange)) or modLine.line
-	if line:match("^%+?0%%? ") or (line:match(" %+?0%%? ") and not line:match("0 to [1-9]")) or line:match(" 0%-0 ") or line:match(" 0 to 0 ") then -- Hack to hide 0-value modifiers
+	if not line:match("^Gain %d+%% to %d+%%") and (line:match("^%+?0%%? ") or (line:match(" %+?0%%? ") and not line:match("0 to [1-9]")) or line:match(" 0%-0 ") or line:match(" 0 to 0 ")) then -- Hack to hide 0-value modifiers
 		return
 	end
 	local colorCode


### PR DESCRIPTION
Fixes [#112](https://github.com/PathOfBuildingCommunity/PathOfBuilding-PoE2/issues/112) .

### Description of the problem being solved:
Gamblesprint not showing movement speed modifier. Check for modifiers with '0' value filtered out the mod. Added logic to allow this one through.

### Steps taken to verify a working solution:
- Verified by looking at item in Items tab
- Verified variants in line with 0.1.1 patch notes

### Before screenshot:
![image](https://github.com/user-attachments/assets/61090252-3cb9-4ea4-88fd-c79dd63bc2a4)


### After screenshot:
![image](https://github.com/user-attachments/assets/558acad5-6473-469a-b979-6a7e5f6f418d)
