### PR TITLE
Fix Seismic Cry being treated as an Attack instead of a hit

### DIFF
--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -10582,7 +10582,7 @@ skills["SeismicCryPlayer"] = {
 			statDescriptionScope = "seismic_cry",
 			baseFlags = {
 				warcry = true,
-				attack = true,
+				hit = true,
 				area = true,
 			},
 			constantStats = {

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -621,7 +621,7 @@ end,
 #skill SeismicCryPlayer
 #startSets
 #set SeismicCryPlayer
-#flags warcry attack area
+#flags warcry hit area
 #mods
 #skillEnd
 


### PR DESCRIPTION
The gem doesn't do attack damage and does not have a accuracy stat. Was a mistake I made when adding the skill flags
Fixes https://github.com/PathOfBuildingCommunity/PathOfBuilding-PoE2/issues/347