### PR TITLE
Fix export of uniques

### DIFF
--- a/src/Data/Uniques/ring.lua
+++ b/src/Data/Uniques/ring.lua
@@ -36,7 +36,7 @@ Ruby Ring
 Implicits: 1
 {tags:fire}+(20-30)% to Fire Resistance
 {tags:life}+(40-60) to maximum Life
-{tags:fire}+(30-40)% to Fire Resistance
+{tags:fire}+(20-30)% to Fire Resistance
 {tags:cold}-(15-10)% to Cold Resistance
 You take Fire Damage instead of Physical Damage from Bleeding
 ]],[[

--- a/src/Export/Uniques/helmet.lua
+++ b/src/Export/Uniques/helmet.lua
@@ -316,7 +316,7 @@ Variant: Current
 {variant:2}UniqueCriticalStrikeChance3
 UniqueDexterity2
 UniqueIntelligence6
-Critical Hits Poison the enemy
+UniquePoisonOnCrit1
 ]],[[
 The Hollow Mask
 Hewn Mask


### PR DESCRIPTION
Atsak's Sight had the raw text instead of the mod name.
I'm not sure where the wrong range for Blistering Bond came from but the mod is correct