### PR TITLE
Add support for importing builds from poe2.ninja

### DIFF
--- a/src/Modules/BuildSiteTools.lua
+++ b/src/Modules/BuildSiteTools.lua
@@ -17,8 +17,8 @@ buildSites.websiteList = {
 		codeOut = "https://pobb.in/", postUrl = "https://pobb.in/pob/", postFields = "", linkURL = "pobb.in/%1"
 	},
 	{
-		label = "PoeNinja", id = "PoeNinja", matchURL = "poe%.ninja/pob/%w+", regexURL = "poe%.ninja/pob/(%w+)%s*$", downloadURL = "poe.ninja/pob/raw/%1",
-		codeOut = "", postUrl = "https://poe.ninja/pob/api/api_post.php", postFields = "api_paste_code=", linkURL="poe.ninja/pob/%1"
+		label = "poe2.ninja", id = "Poe2Ninja", matchURL = "poe2%.ninja/pob/%w+", regexURL = "poe2%.ninja/pob/(%w+)%s*$", downloadURL = "poe2.ninja/pob/raw/%1",
+		codeOut = "", postUrl = "https://poe2.ninja/pob/api/api_post.php", postFields = "api_paste_code=", linkURL="poe2.ninja/pob/%1"
 	},
 	{ 
 		label = "poe2db.tw", id = "PoE2DB", matchURL = "poe2db%.tw/.+", regexURL = "poe2db%.tw/pob/(.+)%s*$", downloadURL = "poe2db.tw/pob/%1/raw", 


### PR DESCRIPTION
### Description of the problem being solved:

poe.ninja does not support Path of Building Path of Exile 2  builds. This pull request changes it to use poe2.ninja instead.
