### PR TITLE
Fix Comparison Tooltip adding Time Lost Jewel mods to incorrect radiusNodes

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -96,7 +96,6 @@ local ItemsTabClass = newClass("ItemsTab", "UndoHandler", "ControlHost", "Contro
 	self.orderedSlots = { }
 	self.slotOrder = { }
 	self.initSockets = true
-	self.skipTimeLostJewelProcessing = false
 	self.slotAnchor = new("Control", {"TOPLEFT",self,"TOPLEFT"}, {96, 76, 310, 0})
 	local prevSlot = self.slotAnchor
 	local function addSlot(slot)
@@ -3061,9 +3060,9 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode)
 			if not main.slotOnlyTooltips or (slot and (slot.nodeId == compareSlot.nodeId or slot.slotName == compareSlot.slotName)) or not slot or slot == compareSlot then
 				local selItem = self.items[compareSlot.selItemId]
 				-- short term fix for Time-Lost jewel processing
-				self.skipTimeLostJewelProcessing = true
+				self.build.treeTab.skipTimeLostJewelProcessing = true
 				local output = calcFunc({ repSlotName = compareSlot.slotName, repItem = item ~= selItem and item or nil})
-				self.skipTimeLostJewelProcessed = false
+				self.build.treeTab.skipTimeLostJewelProcessing = false
 				local header
 				if item == selItem then
 					header = "^7Removing this item from "..compareSlot.label.." will give you:"

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -3059,7 +3059,10 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode)
 		for _, compareSlot in pairs(compareSlots) do
 			if not main.slotOnlyTooltips or (slot and (slot.nodeId == compareSlot.nodeId or slot.slotName == compareSlot.slotName)) or not slot or slot == compareSlot then
 				local selItem = self.items[compareSlot.selItemId]
+				-- short term fix for Time-Lost jewel processing
+				self.skipTimeLostJewelProcessing = true
 				local output = calcFunc({ repSlotName = compareSlot.slotName, repItem = item ~= selItem and item or nil})
+				self.skipTimeLostJewelProcessed = false
 				local header
 				if item == selItem then
 					header = "^7Removing this item from "..compareSlot.label.." will give you:"

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -96,6 +96,7 @@ local ItemsTabClass = newClass("ItemsTab", "UndoHandler", "ControlHost", "Contro
 	self.orderedSlots = { }
 	self.slotOrder = { }
 	self.initSockets = true
+	self.skipTimeLostJewelProcessing = false
 	self.slotAnchor = new("Control", {"TOPLEFT",self,"TOPLEFT"}, {96, 76, 310, 0})
 	local prevSlot = self.slotAnchor
 	local function addSlot(slot)

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -31,6 +31,7 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 	self.specList[1] = new("PassiveSpec", build, latestTreeVersion)
 	self:SetActiveSpec(1)
 	self:SetCompareSpec(1)
+	self.skipTimeLostJewelProcessing = false
 
 	self.anchorControls = new("Control", nil, {0, 0, 0, 20})
 

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -143,7 +143,7 @@ end
 
 local function addStats(jewel, node, spec)
 	-- short term to avoid running the logic on AddItemTooltip
-	if not spec.build.itemsTab.skipTimeLostJewelProcessed then
+	if not spec.build.itemsTab.skipTimeLostJewelProcessing then
 		-- reset node stats to base or override for attributes
 		if spec.hashOverrides and spec.hashOverrides[node.id] then
 			node.sd = copyTable(spec.hashOverrides[node.id].sd, true)

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -143,7 +143,7 @@ end
 
 local function addStats(jewel, node, spec)
 	-- short term to avoid running the logic on AddItemTooltip
-	if not spec.build.itemsTab.skipTimeLostJewelProcessing then
+	if not spec.build.treeTab.skipTimeLostJewelProcessing then
 		-- reset node stats to base or override for attributes
 		if spec.hashOverrides and spec.hashOverrides[node.id] then
 			node.sd = copyTable(spec.hashOverrides[node.id].sd, true)

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -142,23 +142,26 @@ local function setRadiusJewelStats(radiusJewel, radiusJewelStats)
 end
 
 local function addStats(jewel, node, spec)
-	-- reset node stats to base or override for attributes
-	if spec.hashOverrides and spec.hashOverrides[node.id] then
-		node.sd = copyTable(spec.hashOverrides[node.id].sd, true)
-	else
-		node.sd = copyTable(spec.tree.nodes[node.id].sd, true)
-	end
-
-	local radiusJewelStats = { }
-	setRadiusJewelStats(jewel, radiusJewelStats)
-	for _, stat in ipairs(radiusJewelStats) do
-		-- the node and stat types match, add sd to node if it's not already there and it's an 'also grant' mod
-		if not isValueInTable(node.sd, stat.sd) and ((node.type == "Notable" and stat.isNotable) or (node.type == "Normal" and not stat.isNotable))
-			and stat.toAdd then
-			t_insert(node.sd, stat.sd)
+	-- short term to avoid running the logic on AddItemTooltip
+	if not spec.build.itemsTab.skipTimeLostJewelProcessed then
+		-- reset node stats to base or override for attributes
+		if spec.hashOverrides and spec.hashOverrides[node.id] then
+			node.sd = copyTable(spec.hashOverrides[node.id].sd, true)
+		else
+			node.sd = copyTable(spec.tree.nodes[node.id].sd, true)
 		end
+
+		local radiusJewelStats = { }
+		setRadiusJewelStats(jewel, radiusJewelStats)
+		for _, stat in ipairs(radiusJewelStats) do
+			-- the node and stat types match, add sd to node if it's not already there and it's an 'also grant' mod
+			if not isValueInTable(node.sd, stat.sd) and ((node.type == "Notable" and stat.isNotable) or (node.type == "Normal" and not stat.isNotable))
+				and stat.toAdd then
+				t_insert(node.sd, stat.sd)
+			end
+		end
+		spec.tree:ProcessStats(node)
 	end
-	spec.tree:ProcessStats(node)
 	return node.modList
 end
 
@@ -169,7 +172,7 @@ local function addStatsFromJewelToNode(jewel, node, spec)
 		-- if the Time-Lost jewel is socketed, add the stat
 		if itemsTab.activeSocketList then
 			for _, nodeId in pairs(itemsTab.activeSocketList) do
-				local _, socketedJewel = itemsTab:GetSocketAndJewelForNodeID(nodeId)
+				local socketIndex, socketedJewel = itemsTab:GetSocketAndJewelForNodeID(nodeId)
 				if socketedJewel and socketedJewel.baseName:find("Time%-Lost") == 1 then
 					return addStats(jewel, node, spec)
 				end


### PR DESCRIPTION
### Description of the problem being solved:
When the AddItemTooltip is run for item comparison for a time lost jewel, the mods are being added to all jewels within radius of allocated jewel sockets (familiar beast). This is a quick fix that adds a flag when ItemsTab start the compare to essentially tell the Time Lost logic to not add anything and return the node as is. We lose the compare of what the "also grant" mods would do for that socket but users can always move it themselves for now, and I plan to get a better solution out soon.

### Before screenshot:
![image](https://github.com/user-attachments/assets/84433042-ed71-4fd9-bd15-801c2c6cc196)

### After screenshot:
![image](https://github.com/user-attachments/assets/8f575bf6-1049-4360-b9d6-caa810217fbd)
